### PR TITLE
tt-113,114관련 빌드에러 픽스

### DIFF
--- a/src/features/bill/QueryBar.tsx
+++ b/src/features/bill/QueryBar.tsx
@@ -1,5 +1,6 @@
 import SearchBar from '@/shared/components/SearchBar';
 import OrderFilter from './OrderFilter';
+import { Suspense } from 'react';
 
 const QueryBar = () => {
 	return (
@@ -7,7 +8,9 @@ const QueryBar = () => {
 			<div className="flex">
 				<OrderFilter />
 			</div>
-			<SearchBar />
+			<Suspense>
+				<SearchBar />
+			</Suspense>
 		</section>
 	);
 };

--- a/src/shared/hooks/useSearch.ts
+++ b/src/shared/hooks/useSearch.ts
@@ -3,6 +3,7 @@ import { useSearchParams } from 'next/navigation';
 import useDebounce from './useDebounce';
 import useUpdateQueryParam from './useUpdateQueryParam';
 
+// useSearchParams 훅에 의해서 Suspense를 걸어야함 //https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout
 const useSearch = (debounceDelay: number = 500) => {
 	const [searchTerm, setSearchTerm] = useState('');
 	const searchParams = useSearchParams();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
 	"compilerOptions": {
 		"target": "ES2022",
 		"lib": ["ES2022", "DOM", "DOM.Iterable"],
-		"module": "NodeNext",
-		"moduleResolution": "NodeNext",
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"allowJs": true,
 		"skipLibCheck": true,
 		"strict": true,


### PR DESCRIPTION
### 관련 Github issue

#30

### 변경사항 요약

- tsconfig -> nodenext에서 esnext로 변경
- useSearchParams훅이 포함된 useSearch훅을 사용시 Suspense걸기

### 변경사항 관련 파일 및 폴더

- /features/bill/querybar  , tsconfig

### 컴퍼넌트 완성후 체크리스트 혹은 스크린샷

- UI테스트 , 빌드테스트

### 미해결 이슈 및 추가 보고사항

- 없음
