### PR TITLE
Tt-191 프로필 이미지 수정 구현

### DIFF
--- a/src/app/(user)/mypage/profile/page.tsx
+++ b/src/app/(user)/mypage/profile/page.tsx
@@ -1,0 +1,22 @@
+import ProfileImage from '@/features/profile/ProfileImage';
+import { COOKIE_NAME } from '@/shared/const/cookie';
+import { Metadata } from 'next';
+import { cookies } from 'next/headers';
+
+export const metadata: Metadata = {
+	title: '프로필 수정',
+};
+
+export default async function MyProfile() {
+	const cookieStore = await cookies();
+	const img = cookieStore.get(COOKIE_NAME.auth.img)?.value || '';
+
+	return (
+		<div className="flex w-full justify-center px-5 py-12 desktop:py-15">
+			<div className="flex flex-col w-full gap-8 desktop:pt-7 max-w-[480px]">
+				<h1 className="typo-heading2 desktop:typo-heading1 desktop:font-bold">프로필 정보</h1>
+				<ProfileImage img={img} />
+			</div>
+		</div>
+	);
+}

--- a/src/features/layout/Header.tsx
+++ b/src/features/layout/Header.tsx
@@ -13,6 +13,7 @@ import { COOKIE_NAME } from '@/shared/const/cookie';
 
 const Header = async () => {
 	const cookieStore = await cookies();
+	const isLogin = cookieStore.get(COOKIE_NAME.auth.access)?.value;
 	const profileImg = cookieStore.get(COOKIE_NAME.auth.img)?.value;
 
 	return (
@@ -26,7 +27,7 @@ const Header = async () => {
 					<Link href={CLIENT_NAVI_PATH.search.path}>
 						<SearchIcon width={24} height={24} />
 					</Link>
-					{!!profileImg ? (
+					{isLogin && !!profileImg ? (
 						<Link href="/mypage">
 							<Image src={profileImg} alt="프로필 이미지" width={32} height={32} className="rounded-full" />
 						</Link>

--- a/src/features/mypage/AccountMenu.tsx
+++ b/src/features/mypage/AccountMenu.tsx
@@ -3,11 +3,15 @@
 import { SolidBtn } from '@/shared/components/SolidBtn';
 import { clearAuth } from '../auth/utils/cookie';
 import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { CLIENT_NAVI_PATH } from '@/shared/const/url';
 
 const AccountMenu = () => {
 	return (
 		<div className="w-[110px] flex flex-col items-center gap-4 desktop:w-full">
-			<SolidBtn primary={false} label="프로필 수정" className="w-full" />
+			<Link href={CLIENT_NAVI_PATH.myprofile.path}>
+				<SolidBtn primary={false} label="프로필 수정" className="w-full" />
+			</Link>
 			<button
 				type="button"
 				className="hidden desktop:block w-full h-10 text-center py-1 typo-body2-normal font-bold text-label-neutral/88  cursor-pointer hover:bg-bg-gray/60 rounded-[12px]"

--- a/src/features/profile/ProfileImage.tsx
+++ b/src/features/profile/ProfileImage.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState } from 'react';
+import { uploadProfileImg } from './api/server';
+
+type ProfileImageProps = {
+	img: string; // 초기 이미지 URL
+};
+
+const ProfileImage = ({ img }: ProfileImageProps) => {
+	const [preview, setPreview] = useState<string>(img);
+	const [file, setFile] = useState<File | null>(null);
+	const [status, setStatus] = useState<'idle' | 'uploading' | 'success' | 'fail'>('idle');
+
+	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const selectedFile = e.target.files?.[0];
+		if (!selectedFile) return;
+
+		setFile(selectedFile);
+
+		const reader = new FileReader();
+		reader.onloadend = () => {
+			setPreview(reader.result as string);
+		};
+		reader.readAsDataURL(selectedFile);
+	};
+
+	const handleUpload = async () => {
+		if (!file) return;
+
+		setStatus('uploading');
+
+		const formData = new FormData();
+		formData.append('file', file);
+
+		const result = await uploadProfileImg(formData);
+
+		switch (result.status) {
+			case 'success':
+				setStatus('success');
+				alert('이미지가 변경되었습니다');
+				break;
+			case 'relogin':
+				setStatus('fail');
+				alert('로그인이 필요합니다.');
+				break;
+			case 'retry':
+			default:
+				setStatus('fail');
+				alert('업로드 실패. 다시 시도해주세요.');
+				break;
+		}
+	};
+
+	return (
+		<section className="flex w-full gap-5 desktop:px-2 items-center">
+			<label htmlFor="file" className="rounded-full w-[100px] h-[100px] bg-gray-100 overflow-hidden cursor-pointer">
+				{/* eslint-disable-next-line @next/next/no-img-element */}
+				<img src={preview} alt="프로필 이미지" className="w-full h-full object-cover" />
+			</label>
+			<input id="file" type="file" accept="image/*" onChange={handleChange} className="hidden" />
+			<button
+				className="typo-label2 font-bold border-1 px-[14px] py-[7px] rounded-[8px] border-primary-main-normal text-primary-main-normal hover:opacity-85"
+				onClick={handleUpload}
+				disabled={status === 'uploading'}
+			>
+				{status === 'uploading' ? '업로드 중...' : '프로필 사진 업로드'}
+			</button>
+		</section>
+	);
+};
+
+export default ProfileImage;

--- a/src/features/profile/api/server.ts
+++ b/src/features/profile/api/server.ts
@@ -1,0 +1,38 @@
+'use server';
+
+import { logout } from '@/shared/api/auth';
+import { tokenFetcher } from '@/shared/api/fetcher';
+import { COOKIE_NAME } from '@/shared/const/cookie';
+import { RefreshTokenError } from '@/shared/const/error';
+import { cookies } from 'next/headers';
+
+export async function uploadProfileImg(formData: FormData) {
+	const cookieStore = await cookies();
+	const token = cookieStore.get(COOKIE_NAME.auth.access)?.value;
+	if (!token) {
+		return { status: 'relogin' };
+	}
+
+	try {
+		const response = await tokenFetcher<string>('/app/api/image', {
+			method: 'POST',
+			body: formData,
+			cache: 'no-store',
+		});
+
+		// 성공시 반환받은 이미지 url 저장
+		cookieStore.set(COOKIE_NAME.auth.img, response.result ?? '', {
+			httpOnly: false,
+			path: '/',
+		});
+
+		return { status: 'success', img: response.result };
+	} catch (err) {
+		if (err instanceof RefreshTokenError) {
+			await logout(token);
+			return { status: 'relogin' };
+		} else {
+			return { status: 'retry' };
+		}
+	}
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,11 +10,12 @@ export async function middleware(req: NextRequest) {
 
 	// 오타 방지용 상수값 관리
 	const { access, nickname } = COOKIE_NAME.auth;
-	const protectedPaths = ['/onboarding', '/mypage'];
+	const protectedPaths = ['/onboarding', '/mypage', '/mypage/profile'];
 
 	const hasToken = cookieStore.has(access);
 	const nickValue = cookieStore.get(nickname)?.value;
 
+	console.log(cookieStore.get(access)?.value);
 	if (hasToken && nickValue === '' && !(pathname === '/onboarding')) {
 		const referer = req.headers.get('referer') || '';
 		const isFromModalLogin = referer.includes('/modal-login');

--- a/src/shared/const/url.ts
+++ b/src/shared/const/url.ts
@@ -8,6 +8,7 @@ export const CLIENT_NAVI_PATH = {
 	},
 	person: { name: '정치인 피드', path: '/person' },
 	mypage: { name: '마이페이지', path: '/mypage' },
+	myprofile: { name: '프로필 수정', path: '/mypage/profile' },
 	search: { name: '검색페이지', path: '/search' },
 } as const;
 


### PR DESCRIPTION
### 관련 Github issue

#121 

### 변경사항 요약

- middleware에서 비로그인 유저의 프로필 수정 페이지 접근 제어
- 프로필 이미지 수정 기능 임시 구현
- 프로필 수정 페이지 이동 link 추가
- 프로필 수정 route 생성

### 설명

<!--
  (Optional)
  세부 설명이 필요한 경우 기재
-->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 주석 추가 및 수정


## 📸스크린샷 (선택)

<!--
  (Optional)
  리뷰 시에 유심히 봐주었으면 하는 부분 설명
-->

### 체크리스트

- UI테스트, 빌드 테스트

### 미해결 이슈 및 추가 보고사항

- 실제 api테스트 못함 (api 오류 이슈)
