### PR TITLE
tt-292 fix: 외부브라우저 열렸을 경우 deeplink 복귀 로직 추가

### DIFF
--- a/src/features/auth/hooks/useOauthCallback.tsx
+++ b/src/features/auth/hooks/useOauthCallback.tsx
@@ -12,6 +12,13 @@ export const useOauthCallback = (type: OAuthType) => {
 		const code = url.searchParams.get('code');
 		if (!code) return;
 
+		// ✅ 일반 브라우저 팝업 환경
+		if (window.opener) {
+			window.opener.postMessage({ type: 'OAUTH_CODE', code }, '*');
+			window.close?.();
+			return;
+		}
+
 		// ✅ RN WebView 환경 (ReactNativeWebView 존재)
 		if (window.ReactNativeWebView) {
 			try {
@@ -59,11 +66,25 @@ export const useOauthCallback = (type: OAuthType) => {
 			return;
 		}
 
-		// ✅ 일반 브라우저 팝업 환경
-		if (window.opener) {
-			window.opener.postMessage({ type: 'OAUTH_CODE', code }, '*');
-			window.close?.();
-			return;
-		}
+		// 웹이나 rn내부가 아닌경우는 외부 브라우저 -> 딥링크로 복귀 시도
+		const deeplinkUrl = `com.graypick.co.kr://callback?code=${code}`;
+		let opened = false;
+
+		const handleBlur = () => {
+			opened = true; // 앱으로 전환됨
+			clearTimeout(timer);
+			window.removeEventListener('blur', handleBlur);
+		};
+
+		window.addEventListener('blur', handleBlur);
+
+		const timer = setTimeout(() => {
+			window.removeEventListener('blur', handleBlur);
+			if (!opened) {
+				alert('앱이 설치되어 있지 않아요. 앱에서 다시 시도해주세요.');
+			}
+		}, 1000);
+
+		window.location.href = deeplinkUrl;
 	}, [queryClient, router, type]);
 };


### PR DESCRIPTION
### 관련 Github issue

#232 

### 변경사항 요약

- 팝업창의 부모가 없거나 rn 웹뷰 내부가 아니라면 deeplink로 app으로 코드 돌려주도록 로직수정

### 설명

<!--
  (Optional)
  세부 설명이 필요한 경우 기재
-->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

<!--
  (Optional)
  리뷰 시에 유심히 봐주었으면 하는 부분 설명
-->

### 체크리스트

- UI테스트, 빌드 테스트

### 미해결 이슈 및 추가 보고사항

- 없음
