### PR TITLE
feat: 폴리타입 질문 네비 버튼 모바일 하단 좌우 배치 및 카드 높이 고정

### DIFF
--- a/src/features/politype/QuestionContent.tsx
+++ b/src/features/politype/QuestionContent.tsx
@@ -19,22 +19,40 @@ const QuestionContent = () => {
 			</div>
 
 			<div className="relative z-10">
-				<QuestionCard
-					questionNum={currentQuestion.id}
-					questionText={currentQuestion.text}
-					prevBtn={!isFirst ? <NavBtn direction="prev" disabled={false} onClick={prev} inline /> : <div className="size-[48px]" />}
-					nextBtn={!isLast ? <NavBtn direction="next" disabled={!hasCurrentAnswer} onClick={next} inline /> : <div className="size-[48px]" />}
-				/>
+				<QuestionCard questionNum={currentQuestion.id} questionText={currentQuestion.text} />
 			</div>
 
 			<div className="relative z-10 w-full flex justify-center px-1">
 				<LikertScale selectedValue={currentAnswer} onSelect={select} />
 			</div>
 
-			{isLast && (
-				<div className="absolute inset-x-0 bottom-0 z-10 flex justify-center px-8 py-14">
+			{/* 모바일 하단 네비 영역: 항상 좌우 정렬, 마지막엔 우측에 결과확인 버튼 */}
+			<div className="desktop:hidden absolute inset-x-0 bottom-0 z-10 flex items-center justify-between gap-5 px-5 pb-10">
+				{!isFirst ? <NavBtn direction="prev" disabled={false} onClick={prev} inline /> : <div className="size-[48px]" />}
+				{isLast ? (
 					<SolidBtn
 						label="결과확인하기"
+						size="large"
+						disabled={!hasCurrentAnswer}
+						onClick={submit}
+						className="flex-1 bg-primary-sub-normal text-label-normal typo-headline1 font-[600]"
+					/>
+				) : (
+					<NavBtn direction="next" disabled={!hasCurrentAnswer} onClick={next} inline />
+				)}
+			</div>
+
+			{/* 데스크탑 사이드 네비 */}
+			<div className="hidden desktop:block">
+				{!isFirst && <NavBtn direction="prev" disabled={false} onClick={prev} />}
+				{!isLast && <NavBtn direction="next" disabled={!hasCurrentAnswer} onClick={next} />}
+			</div>
+
+			{/* 데스크탑 마지막 페이지 제출 - 좌 버튼 없이 단독이므로 가운데 정렬 */}
+			{isLast && (
+				<div className="hidden desktop:flex absolute inset-x-0 bottom-0 z-10 justify-center px-8 py-14">
+					<SolidBtn
+						label="결과 확인하기"
 						size="large"
 						disabled={!hasCurrentAnswer}
 						onClick={submit}
@@ -42,11 +60,6 @@ const QuestionContent = () => {
 					/>
 				</div>
 			)}
-
-			<div className="hidden desktop:block">
-				{!isFirst && <NavBtn direction="prev" disabled={false} onClick={prev} />}
-				{!isLast && <NavBtn direction="next" disabled={!hasCurrentAnswer} onClick={next} />}
-			</div>
 		</div>
 	);
 };

--- a/src/features/politype/components/QuestionCard.tsx
+++ b/src/features/politype/components/QuestionCard.tsx
@@ -1,28 +1,22 @@
-import { ReactNode } from 'react';
-
 interface QuestionCardProps {
 	questionNum: number;
 	questionText: string;
-	prevBtn?: ReactNode;
-	nextBtn?: ReactNode;
 }
 
 const CLIP_PATH = 'polygon(0 16px, 16px 0, 100% 0, 100% calc(100% - 16px), calc(100% - 16px) 100%, 0 100%)';
 
-const QuestionCard = ({ questionNum, questionText, prevBtn, nextBtn }: QuestionCardProps) => {
+const QuestionCard = ({ questionNum, questionText }: QuestionCardProps) => {
 	return (
 		<div className="flex w-full flex-col items-center gap-3 desktop:gap-5">
-			<div className="flex w-full items-center justify-between desktop:justify-center">
-				<div className="desktop:hidden">{prevBtn}</div>
+			<div className="flex w-full items-center justify-center">
 				<p className="typo-title2 font-bold text-line-solid-alternative text-center text-shadow">{`Q${questionNum}`}</p>
-				<div className="desktop:hidden">{nextBtn}</div>
 			</div>
 
 			{/* 테두리용 외곽 */}
 			<div className="w-full max-w-[360px] self-stretch bg-[#C8F5D1] p-[2px]" style={{ clipPath: CLIP_PATH }}>
 				{/* 내부 배경 + 텍스트 */}
 				<div
-					className="flex w-full items-center justify-center px-10 py-[71px] backdrop-blur-[6px]"
+					className="flex h-[198px] w-full items-center justify-center px-10 backdrop-blur-[6px]"
 					style={{ clipPath: CLIP_PATH, backgroundColor: 'rgba(0, 213, 162, 0.7)' }}
 				>
 					<p className="typo-heading2 font-bold text-line-solid-alternative text-center drop-shadow-[0_6px_12px_rgba(0,0,0,0.12)]">{questionText}</p>


### PR DESCRIPTION
### 관련 Github issue

#261 

### 변경사항 요약

  네비게이션 버튼 위치 변경                                                                                                                                             
- 기존: Q번호 좌우에 이전/다음 버튼 인라인 배치                                                                                                                     
 - 변경: 화면 하단 좌우 끝에 고정 배치 (모바일 전용)                                                                                                                   
 - 데스크탑은 기존 absolute 사이드 버튼 방식 유지   
                                                                                                                                                                      
 마지막 문항 처리                                                                                                                                                    
- 모바일: 하단 우측 "다음" 버튼 자리에 "결과 확인하기" 버튼으로 대체, 좌측 이전 버튼은 유지
- 데스크탑: 결과 확인하기 버튼 단독으로 하단 가운데 정렬
                                                                                                                                                                                                                                                                                   질문 카드 높이 고정                                                                                                                                                   
- 기존 py-[71px] 패딩 방식 → h-[198px] 고정 높이로 변경
                                                           

### 설명

<!--
  (Optional)
  세부 설명이 필요한 경우 기재
-->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 기능 개선
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

<!--
  (Optional)
  리뷰 시에 유심히 봐주었으면 하는 부분 설명
-->

### 체크리스트

- UI테스트, 빌드 테스트

### 미해결 이슈 및 추가 보고사항

- 없음
